### PR TITLE
[Fix/Site-2000] Corrige a exibição dos dados estruturados de breadcrumb

### DIFF
--- a/commerce/sections/Seo/SeoPLP.tsx
+++ b/commerce/sections/Seo/SeoPLP.tsx
@@ -81,7 +81,7 @@ function Section({ jsonLD, ...props }: Props) {
 
     return {
       "@type": "BreadcrumbList",
-      "itemListElement": data.breadcrumb
+      "itemListElement": data.breadcrumb.itemListElement
     };
   }
 


### PR DESCRIPTION
Os dados estruturados de breadcrumb estava vindo duplicado. A ideia era remover essa duplicação para que o search console reconheça como um dado estruturado valido.

O problema acontecia porque estavamos retornando ele duas vezes e a ideia da correção é que a gente retorne o type e depois apenas a lista de itens dentro dela.

Abaixo coloco um print do antes:
![image](https://github.com/user-attachments/assets/25be6f7b-a9ad-443a-9ec5-e777621c8151)

E agora com a correção, como isso deve ficar: 
![image](https://github.com/user-attachments/assets/944082a8-f9a5-4ba9-ab02-b9972b6a9381)

