### PR TITLE
Fix(VTEX): Validate item quantities in simulation to prevent CHK0023

### DIFF
--- a/vtex/actions/cart/simulation.ts
+++ b/vtex/actions/cart/simulation.ts
@@ -1,6 +1,7 @@
 import { AppContext } from "../../mod.ts";
 import type { SimulationOrderForm } from "../../utils/types.ts";
 import { getSegmentFromBag } from "../../utils/segment.ts";
+import { logger } from "@deco/deco/o11y";
 
 export interface Item {
   id: number;
@@ -28,6 +29,67 @@ const action = async (
   const cookie = req.headers.get("cookie") ?? "";
   const { vcsDeprecated } = ctx;
   const { items, postalCode, country, RnbBehavior = 1 } = props;
+
+  const invalidItems = items.filter(
+    (item) =>
+      item.quantity == null ||
+      item.quantity < 1 ||
+      Number.isNaN(item.quantity) ||
+      !Number.isFinite(item.quantity),
+  );
+
+  if (invalidItems.length > 0) {
+    const url = new URL(req.url);
+    logger.warn(
+      "Simulation received items with invalid quantities (CHK0023)",
+      {
+        invalidItems,
+        postalCode,
+        country,
+        referer: req.headers.get("referer"),
+        origin: req.headers.get("origin"),
+        pathname: url.pathname,
+        totalItems: items.length,
+        invalidCount: invalidItems.length,
+      },
+    );
+  }
+
+  const validItems = items.filter(
+    (item) =>
+      item.quantity != null &&
+      item.quantity >= 1 &&
+      !Number.isNaN(item.quantity) &&
+      Number.isFinite(item.quantity),
+  );
+
+  if (validItems.length === 0) {
+    return {
+      items: [],
+      ratesAndBenefitsData: { rateAndBenefitsIdentifiers: [], teaser: [] },
+      paymentData: {
+        updateStatus: "",
+        installmentOptions: [],
+        paymentSystems: [],
+        payments: [],
+        giftCards: [],
+        giftCardMessages: [],
+        availableAccounts: [],
+        availableTokens: [],
+        availableAssociations: {},
+      },
+      selectableGifts: [],
+      postalCode: postalCode ?? "",
+      country: country ?? "",
+      logisticsInfo: [],
+      messages: [],
+      purchaseConditions: { itemPurchaseConditions: [] },
+      pickupPoints: [],
+      totals: [],
+      allowMultipleDeliveries: false,
+    } as SimulationOrderForm;
+  }
+
   const segment = getSegmentFromBag(ctx);
 
   const response = await vcsDeprecated[
@@ -38,7 +100,7 @@ const action = async (
       sc: segment?.payload.channel,
     },
     {
-      body: { items, country, postalCode },
+      body: { items: validItems, country, postalCode },
       headers: {
         accept: "application/json",
         "content-type": "application/json",


### PR DESCRIPTION
## Summary
- Filter out items with invalid quantities (0, NaN, negative, undefined) in `vtex/actions/cart/simulation.ts` before calling the VTEX simulation API
- Log a warning with debugging context (invalid items, referer, origin, pathname) when invalid quantities are detected, to help trace which services/pages send bad data
- Return an empty `SimulationOrderForm` early if no valid items remain, avoiding the VTEX API call entirely

## Context
PR #1039 added client-side quantity guards in Houston's shipping simulation components, but CHK0023 errors persist across 20+ services. This fix addresses the root cause at the shared `simulate` action level — the single gateway for all client-initiated simulation calls.

## Test plan
- [ ] Verify simulation works normally with valid items (quantity >= 1)
- [ ] Verify items with `quantity: 0`, `NaN`, `-1`, `undefined` are filtered out and logged
- [ ] Verify empty items array returns empty SimulationOrderForm without calling VTEX
- [ ] Verify mixed valid/invalid items only sends valid items to VTEX
- [ ] Monitor logs for CHK0023 warnings to identify remaining callers sending bad quantities

🤖 Generated with [Claude Code](https://claude.com/claude-code)